### PR TITLE
Revise Terraform/Ansible outputs logging

### DIFF
--- a/crczp/sandbox_common_lib/log_output_mixin.py
+++ b/crczp/sandbox_common_lib/log_output_mixin.py
@@ -1,0 +1,32 @@
+"""
+Output view mixins for compressed responses.
+"""
+
+from rest_framework.response import Response
+
+from crczp.sandbox_common_lib import utils
+
+
+class CompressedOutputMixin:
+    def create_outputs_response(self, outputs_queryset, from_row: int) -> Response:
+        """
+        Create a compressed response for outputs endpoints.
+
+        :param outputs_queryset: QuerySet of output objects with 'content' field
+        :param from_row: The from_row parameter for pagination
+        :return: Compressed Response with content and rows
+        """
+        outputs = outputs_queryset.filter(id__gt=from_row).order_by('id')
+
+        content_lines = [output.content for output in outputs]
+        content = '\n'.join(content_lines) if content_lines else ''
+
+        if from_row == 0:
+            content = content.lstrip()
+
+        rows = outputs.last().id if outputs.exists() else from_row
+
+        return utils.create_compressed_response({
+            'content': content,
+            'rows': rows
+        })

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "crczp-sandbox-service"
-version = "1.2.5"
+version = "1.3.0"
 description = "simplifies manipulation of OpenStack cloud platform for CyberRangeCZ Platform purposes"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -176,7 +176,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -464,7 +464,7 @@ wheels = [
 
 [[package]]
 name = "crczp-sandbox-service"
-version = "1.2.4"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "better-profanity" },


### PR DESCRIPTION
- Added utility for sending GZIP compressed JSON responses
- `/outputs` endpoints no longer return every line as a separate pagination entry
- Added support for incremental queries using `from_row` param
- Added automatic leading whitespace stripping
- Logs are sent compressed if over 5KB
  - test on sample Ansible output shows ~12x size compression with GZIP

The new DTO for log outputs is:
```
{
  # Single string of log outputs
  content: string 
  
  # Database ID of the last row
  # Does not match the number of rows in string
  # Is used in the `from_row` query of next request
  rows: number 
}
```